### PR TITLE
Set `-o pipefail` by default in content

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -53,6 +53,8 @@ inputs:
       #!/usr/bin/env bash
       # fail if any commands fails
       set -e
+      # make pipelines' return status equal the last command to exit with a non-zero status
+      set -o pipefail
       # debug log
       set -x
 

--- a/step.yml
+++ b/step.yml
@@ -53,7 +53,7 @@ inputs:
       #!/usr/bin/env bash
       # fail if any commands fails
       set -e
-      # make pipelines' return status equal the last command to exit with a non-zero status
+      # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
       set -o pipefail
       # debug log
       set -x


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context
* By default, the shell determines the return status of a pipeline based on the return status of the last command.
* This can be dangerous since a failing command in a pipe won't automatically result in a failure, even if `-e` is set in the shell.
* Since we already evangelize using `-e` in the default value of `content`, we should also set `-o pipefail` as a best practice.

### Changes
* **Set `-o pipefail` shell option in the default value of `content`.**