### PR TITLE
Allow Bash shell-style execution for scripts that begin with a shebang

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,7 +3,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - STEP_VERSION: 1.2.0
+  - STEP_VERSION: 1.3.0
 
   - IS_DEBUG: "no"
   # set these in your .bitrise.secrets.yml

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -64,6 +64,18 @@ workflows:
         - runner_bin: go run
         - script_file_path: main.go
         - is_debug: $IS_DEBUG
+    - path::./:
+        inputs:
+        - content: |-
+            set -eo pipefail
+            cd ../tests
+            testdir="$(pwd)"
+            for t in *; do
+                echo -n "| Running test $t --> "
+                "$testdir/$t"
+            done
+        - runner_bin: bash
+        - is_debug: $IS_DEBUG
 
   # ----------------------------------------------------------------
   # --- workflows to create Release

--- a/step.sh
+++ b/step.sh
@@ -21,6 +21,16 @@ function debug_echo {
 	fi
 }
 
+function run_bash {
+	# bash syntax check
+	${runner_bin} -n "${CONFIG_tmp_script_file_path}"
+	if [ $? -ne 0 ] ; then
+		echo " [!] Bash: Syntax Error!"
+		rm "${CONFIG_tmp_script_file_path}"
+		exit 1
+	fi
+	${runner_bin} "${CONFIG_tmp_script_file_path}"
+}
 
 debug_echo
 debug_echo "==> Start"
@@ -43,15 +53,10 @@ cat <<< "${content}" > "${CONFIG_tmp_script_file_path}"
 
 debug_echo
 if [[ "$(basename "${runner_bin}")" == "bash" ]] ; then
-	# bash syntax check
-	${runner_bin} -n "${CONFIG_tmp_script_file_path}"
-	if [ $? -ne 0 ] ; then
-		echo " [!] Bash: Syntax Error!"
-		rm "${CONFIG_tmp_script_file_path}"
-		exit 1
-	fi
+	run_bash
+else
+	${runner_bin} "${CONFIG_tmp_script_file_path}"
 fi
-${runner_bin} "${CONFIG_tmp_script_file_path}"
 script_result=$?
 
 debug_echo

--- a/step.sh
+++ b/step.sh
@@ -22,6 +22,12 @@ function debug_echo {
 }
 
 function run_bash {
+	if has_shebang "${CONFIG_tmp_script_file_path}"; then
+		chmod +x "${CONFIG_tmp_script_file_path}"
+		"${CONFIG_tmp_script_file_path}"
+		return
+	fi
+
 	# bash syntax check
 	${runner_bin} -n "${CONFIG_tmp_script_file_path}"
 	if [ $? -ne 0 ] ; then
@@ -30,6 +36,16 @@ function run_bash {
 		exit 1
 	fi
 	${runner_bin} "${CONFIG_tmp_script_file_path}"
+}
+
+function has_shebang {
+	local file="$1"
+	local topline="$(head -n1 "$file")"
+	if [[ "${topline:0:2}" == "#!" ]]; then
+		true
+	else
+		false
+	fi
 }
 
 debug_echo

--- a/step.sh
+++ b/step.sh
@@ -39,7 +39,7 @@ if [ ! -z "${script_file_path}" ] ; then
 	CONFIG_tmp_script_file_path="${script_file_path}"
 fi
 
-echo -n "${content}" > "${CONFIG_tmp_script_file_path}"
+cat <<< "${content}" > "${CONFIG_tmp_script_file_path}"
 
 debug_echo
 if [[ "$(basename "${runner_bin}")" == "bash" ]] ; then

--- a/tests/bash_test.sh
+++ b/tests/bash_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+TEST_DIR="$(cd "$(dirname "$BASH_SOURCE[0]")"; pwd)"
+main() {
+	local expected=$(uuidgen)
+	local script="echo \"$expected\""
+
+	local result=$(content="$script" runner_bin=bash sh "${TEST_DIR}/../step.sh")
+	if [[ $result != $expected ]]; then
+		echo "Bash test failed ($result != $expected)"
+		exit 1
+	fi
+	echo "Bash test passed"
+}
+
+main "$@"

--- a/tests/shebang_test.sh
+++ b/tests/shebang_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+TEST_DIR="$(cd "$(dirname "$BASH_SOURCE[0]")"; pwd)"
+main() {
+	local expected=$(uuidgen)
+	read -rd '' script <<- EOF
+	#!/usr/bin/env ruby
+	puts "$expected"
+EOF
+
+	local result=$(content="$script" runner_bin=bash sh "${TEST_DIR}/../step.sh")
+	if [[ $result != $expected ]]; then
+		echo "Shebang test failed ($result != $expected)"
+		exit 1
+	fi
+	echo "Shebang test passed"
+}
+
+main "$@"


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

This adds support for any scripts that have the [shebang character sequence](https://en.wikipedia.org/wiki/Shebang_(Unix)) at the start of their files.

The usage of "bash" in the scripting world needs some context.  The Bash shell is ubiquitous.  Unfortunately, some of its mechanisms may be assumed rather than understood.  Many of the scripts that we see start with the shebang line.  However, the Script Step doesn't acknowledge that line.  Instead, all Bash scripts are executed as, well, Bash scripts.  This may lead to confusion as users wonder why their shebang isn't being recognized by the script step.

The changes here enable users to assume Bash _behavior_ at the expense of precision.  "Bash" as a script runner will assume that the script can be executed as in the shell rather than executed by the Bash interpreter.  This may match the expectations of users that aren't distinguishing between their shell behavior and how the interpreter would behave.  It also makes it easier to users to copy-and-paste scripts with shebangs into the Step without requiring further modifications.

### Changes

* Updates `bash` runners to set scripts to executable and run directly with shell executions when files begin with `#!`
* Adds some tests for both shebang and bash-runner use cases
